### PR TITLE
fixed restore button bug

### DIFF
--- a/src/components/sub-header/SubHeader.jsx
+++ b/src/components/sub-header/SubHeader.jsx
@@ -58,13 +58,10 @@ const SubHeader = () => {
   // LOAD CATEGORIES
   useEffect(() => {
     fetchCategories();
+    if (searchValue !== "getall") {
+      setIsRedoActive(true);
+    }
   }, []);
-
-  // useEffect(() => {
-  //   setSearchValue("getall");
-  // }, [handleRedoClick])
-
-  
 
   return (
     // MAIN CONTAINER


### PR DESCRIPTION
## PROBLEM
When you search or filter something and then choose one of your results you go to that auction no problem so far but when you go back to startpage the latest search or filter is still applied but the restore button is not present and to restore you have to refresh the page.

## DONE
Fixed so that the restore button is present when you go back so you can reset.

## TEST
- Search or filter something
- choose an auction
- Go back to startpage either through back arrow in browser or through the menu.
- Now the restore button should be present and you can restore the page to show all auctions.

Closes #107 